### PR TITLE
Update GNOME runtime to version 47

### DIFF
--- a/io.github.phastmike.tags.json
+++ b/io.github.phastmike.tags.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.phastmike.tags",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "45",
+    "runtime-version" : "47",
     "sdk" : "org.gnome.Sdk",
     "command" : "tags",
     "finish-args" : [


### PR DESCRIPTION
GNOME runtime version 45 has reached EOL.